### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export default {
     intersectionOptions: {
       root: null,
       rootMargin: '0px 0px 0px 0px',
-      thresholds: [0, 100]
+      threshold: [0, 100]
     } // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
   })
   methods: {


### PR DESCRIPTION
The commit in this pull request if merged will change the parameter in `intersectionOptions` from `thresholds` to `threshold`. 

According to the docs, `threshold` is the param to use. Without this change the browser will switch to the default value as stated in the docs [here](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)

I raised an issue on it [here](https://github.com/scaccogatto/vue-waypoint/issues/22#issue-394054925)