### PR TITLE
clarify SSR docs, remove reference to <no-ssr>

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ Vue.use(VueWaypoint)
 ```
 
 ### 4. Update the `nuxt.config.js` to reference the plugin file
-The `ssr: false` flag will make sure `v-waypoint` is rendered and used only in the client-side bundle.
+The `mode: 'client'` option will make sure `v-waypoint` is rendered and used only in the client-side bundle.
 ```js
 ...
   plugins: [    
     ...
     { src: "~/plugins/v-waypoint.client.js",
-      ssr: false
+      mode: 'client'
     }
   ],
 ...

--- a/README.md
+++ b/README.md
@@ -142,20 +142,15 @@ import VueWaypoint from "vue-waypoint"
 Vue.use(VueWaypoint)
 ```
 
-### 4. Update the `nuxt.config.js` to refer the plugin file
+### 4. Update the `nuxt.config.js` to reference the plugin file
+The `ssr: false` flag will make sure `v-waypoint` is rendered and used only in the client-side bundle.
 ```js
 ...
   plugins: [    
     ...
-    "~/plugins/v-waypoint.client.js"
+    { src: "~/plugins/v-waypoint.client.js",
+      ssr: false
+    }
   ],
 ...
-```
-
-### 5. Remember to enclose the usage of `v-waypoint` tags with the `<no-ssr>`
-This will make sure `v-waypoint` is rendered and used only in client side.
-```html
-    <no-ssr>
-      <v-waypoint @waypoint="loadMore"></v-waypoint>
-    </no-ssr>
 ```


### PR DESCRIPTION
This updates the `README`: the previously described method for SSR uses the deprecated `<no-ssr>` option; it's easier to just set the `ssr: false` flag in `nuxt.config.js`. Have confirmed that this works with the latest Nuxt.