### PR TITLE
chore: add package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "private": false,
   "main": "dist/vue-waypoint.umd.min.js",
   "typings": "./dist/typings/src/components/Waypoint/index.d.ts",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/scaccogatto/vue-waypoint"
+  },
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",


### PR DESCRIPTION
> Specify the place where your code lives. This is helpful for people who want to contribute. If the git repo is on GitHub, then the npm docs command will be able to find you.
> https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository