### PR TITLE
docs: fix variable name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm i vue-waypoint
 ```html
 <script lang="ts">
 import { defineComponent } from "vue";
-import { VueWaypoint } from 'vue-waypoint'
+import { Waypoint } from 'vue-waypoint'
 
 export default defineComponent({
   name: "SomeComponent",


### PR DESCRIPTION
Dear @scaccogatto,

I have found a small issue on the `README.md` file that the name of an imported variable is wrong. I check the [source code](https://github.com/scaccogatto/vue-waypoint/blob/master/src/App.vue) and make sure the import sentence:
```JavaScript
import { VueWaypoint } from 'vue-waypoint'
```
should be replaced by:
```JavaScript
import { Waypoint } from 'vue-waypoint'
```
Otherwise, this will cause a runtime error.