### PR TITLE
feat(ci): sposta la demo su GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - run: npm run build-only -- --base=/${{ github.event.repository.name }}/
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: dist
+
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Demo
 
-[Simple demo page](https://vue-waypoint.netlify.app/) — open your browser console and watch the events fire while scrolling up and down.
+[Simple demo page](https://scaccogatto.github.io/vue-waypoint/) — open your browser console and watch the events fire while scrolling up and down.
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -2,9 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite App</title>
+    <title>vue-waypoint</title>
   </head>
   <body>
     <div id="app"></div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,12 @@
+# La demo vive su GitHub Pages. Questo sito resta solo per non rompere i link
+# vecchi (README pubblicato su npm, blob GitHub delle release passate).
+
 [build]
-  command = "npm run build-only"
+  command = "mkdir -p dist"
   publish = "dist"
+
+[[redirects]]
+  from = "/*"
+  to = "https://scaccogatto.github.io/vue-waypoint/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
Sposta la demo da Netlify a GitHub Pages.

- `.github/workflows/pages.yml`: build della demo e deploy su Pages a ogni push su master. Il base path viene da `github.event.repository.name`, quindi il file e' riusabile tale e quale sugli altri repo.
- `netlify.toml` diventa un redirect 301 verso https://scaccogatto.github.io/vue-waypoint/. Serve perche' il README pubblicato su npm (v5.1.0) linka ancora l'URL Netlify.
- README aggiornato al nuovo URL.
- `index.html`: `<title>` da 'Vite App' a 'vue-waypoint', e via il `<link rel=icon href=/favicon.ico>` che puntava a un file inesistente (404) e con il base path sarebbe finito fuori dal sito.

Nota: Pages oggi e' su sorgente legacy (branch `vue2`, cartella `/docs`), cioe' la vecchia demo Vue 2. Passo la sorgente a "GitHub Actions" prima del merge.

Verifica locale: `npm run build-only -- --base=/vue-waypoint/` produce asset con prefisso corretto; lint, typecheck, coverage e build della libreria verdi.