### PR TITLE
fix(ci): redirect Netlify senza build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,6 @@
 # La demo vive su GitHub Pages. Questo sito resta solo per non rompere i link
 # vecchi (README pubblicato su npm, blob GitHub delle release passate).
+# Nessuna build: si pubblica netlify/ cosi' com'e'.
 
 [build]
-  command = "mkdir -p dist"
-  publish = "dist"
-
-[[redirects]]
-  from = "/*"
-  to = "https://scaccogatto.github.io/vue-waypoint/:splat"
-  status = 301
-  force = true
+  publish = "netlify"

--- a/netlify/_redirects
+++ b/netlify/_redirects
@@ -1,0 +1,1 @@
+/*  https://scaccogatto.github.io/vue-waypoint/:splat  301!

--- a/netlify/index.html
+++ b/netlify/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=https://scaccogatto.github.io/vue-waypoint/" />
+    <title>vue-waypoint</title>
+  </head>
+  <body>
+    <p>
+      The demo moved to
+      <a href="https://scaccogatto.github.io/vue-waypoint/">scaccogatto.github.io/vue-waypoint</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Il redirect introdotto in #105 non e' mai andato in produzione: `command = "mkdir -p dist"` con `publish = "dist"` pubblica una cartella vuota e Netlify fa fallire il deploy, quindi il sito continuava a servire il deploy precedente (`/probe-redirect` rispondeva 404 invece di 301).

Ora nessuna build: si pubblica la cartella statica `netlify/`, con `_redirects` (regola forzata `301!` su `/*`) e un `index.html` di fallback con meta-refresh.

Verifica dopo il merge: `curl -I https://vue-waypoint.netlify.app/qualsiasi-cosa` deve dare 301 verso scaccogatto.github.io/vue-waypoint.