### PR TITLE
chore: build della demo in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Build demo
+        run: npm run build-only


### PR DESCRIPTION
`typecheck` qui gia' copre `src/App.vue` via vue-tsc. Mancava solo la build della demo, che girava solo nel workflow Pages, cioe' dopo il merge: una demo rotta se ne accorgeva solo a deploy fallito.

Verifica: `npm run build-only` e `npm run typecheck` verdi in locale.